### PR TITLE
Make JSON parsing robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Any case class property with default values or Optional values now
+fallback to defaults if parsing fails.
+
 ## [0.4.5] - 2018-06-18
 
 ### Changed

--- a/src/main/scala/com/github/vitalsoftware/macros/JsonFormatAnnotation.scala
+++ b/src/main/scala/com/github/vitalsoftware/macros/JsonFormatAnnotation.scala
@@ -48,31 +48,53 @@ class jsonMacro(useDefaults: Boolean) {
       }
     }
 
+    /**
+     * Generates implicit json.Formats that fallback to the defaults is the initial parsing fails.
+     */
     def jsonFormatter(className: TypeName, fields: List[ValDef]) = {
       fields.length match {
         case 0 => c.abort(c.enclosingPosition, "Cannot create json formatter for case class with no fields")
         case _ =>
-          if (useDefaults) {
-            q"implicit val jsonAnnotationFormat = play.api.libs.json.Json.using[play.api.libs.json.Json.WithDefaultValues].format[$className]"
+          val lowPriorityFormats = if (useDefaults) {
+            q"private val lowPriorityFormats = play.api.libs.json.Json.using[play.api.libs.json.Json.WithDefaultValues].format[$className]"
           } else {
-            q"implicit val jsonAnnotationFormat = play.api.libs.json.Json.format[$className]"
+            q"private val lowPriorityFormats = play.api.libs.json.Json.format[$className]"
           }
+
+          Seq(
+            lowPriorityFormats,
+            q"""
+                private val robustReads = new play.api.libs.json.Reads[$className] {
+                  override def reads(json: play.api.libs.json.JsValue) = lowPriorityFormats.reads(json) match {
+                    case s: play.api.libs.json.JsSuccess[_] => s
+                    case e: play.api.libs.json.JsError =>
+                      val transforms = e.errors.map(_._1)
+                        .filter(_.path.size == 1)
+                        .map(_.json.prune)
+                        .reduce(_ andThen _)
+
+                      json.transform(transforms).flatMap(lowPriorityFormats.reads _).orElse(e)
+                  }
+                }
+              """,
+            q"implicit val jsonAnnotationFormat = play.api.libs.json.Format(robustReads, lowPriorityFormats)"
+          )
       }
     }
 
-    def modifiedCompanion(compDeclOpt: Option[ModuleDef], format: ValDef, className: TypeName) = {
+    def modifiedCompanion(compDeclOpt: Option[ModuleDef], format: Seq[Tree], className: TypeName) = {
       compDeclOpt map { compDecl =>
         // Add the formatter to the existing companion object
         val q"object $obj extends ..$bases { ..$body }" = compDecl
         q"""
           object $obj extends ..$bases {
             ..$body
-            $format
+            ..$format
           }
         """
       } getOrElse {
         // Create a companion object with the formatter
-        q"object ${className.toTermName} { $format }"
+        q"object ${className.toTermName} { ..$format }"
       }
     }
 

--- a/src/test/scala/com/github/vitalsoftware/macros/JsonFormatAnnotationTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/macros/JsonFormatAnnotationTest.scala
@@ -5,6 +5,7 @@ import play.api.libs.json._
 
 @json case class Person(name: String, age: Int, gender: Option[String])
 @jsonDefaults case class Person2(name: String, age: Int = 7, gender: Option[String] = None)
+@jsonDefaults case class Test(f1: Int = 1, f2:  String = "2", f3: Boolean = true, f4: Option[Test])
 
 class JsonFormatAnnotationTest extends Specification {
 
@@ -65,9 +66,26 @@ class JsonFormatAnnotationTest extends Specification {
       )
 
       val result = Json.fromJson[Person](json)
-      result must beAnInstanceOf[JsError]
-      result.asInstanceOf[JsError].errors.head._1.path.head.asInstanceOf[KeyPathNode].key mustEqual "age"
 
+      result match {
+        case e: JsError =>
+          e.errors.head._1.path.head.asInstanceOf[KeyPathNode].key mustEqual("age")
+          e.errors.head._2.head.message must contain("error.expected.jsnumber")
+        case _ =>
+          result must beAnInstanceOf[JsError]
+      }
+    }
+
+    "multiple defaults must get replaced" in {
+      val json = Json.obj("f1" -> "str", "f2" -> false, "f3" -> 3, "f4" -> "not test")
+      val result = Json.fromJson[Test](json)
+      result match {
+        case JsSuccess(value, paths) =>
+          value mustEqual(Test(f4 = None))
+          paths.path.map(_.toString) must contain(allOf("/f1", "/f2", "/f3", "/f4"))
+            .setMessage("success result should contain paths of failed keys")
+        case _ => result must beAnInstanceOf[JsSuccess[Test]]
+      }
     }
   }
 }

--- a/src/test/scala/com/github/vitalsoftware/macros/JsonFormatAnnotationTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/macros/JsonFormatAnnotationTest.scala
@@ -3,8 +3,8 @@ package com.github.vitalsoftware.macros
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 
-@json case class Person(name: String, age: Int)
-@jsonDefaults case class Person2(name: String, age: Int = 7)
+@json case class Person(name: String, age: Int, gender: Option[String])
+@jsonDefaults case class Person2(name: String, age: Int = 7, gender: Option[String] = None)
 
 class JsonFormatAnnotationTest extends Specification {
 
@@ -12,11 +12,12 @@ class JsonFormatAnnotationTest extends Specification {
 
     "create correct formatter for case class with >= 2 fields" in {
 
-      val person = Person("Victor Hugo", 46)
+      val person = Person("Victor Hugo", 46, Some("Male"))
       val json = Json.toJson(person)
       json === Json.obj(
         "name" -> "Victor Hugo",
-        "age" -> 46
+        "age" -> 46,
+        "gender" -> "Male"
       )
       Json.fromJson[Person](json).asOpt must beSome(person)
     }
@@ -33,6 +34,40 @@ class JsonFormatAnnotationTest extends Specification {
         "age" -> 7
       )
       Json.fromJson[Person2](Json.obj("name" -> "Victor Hugo")).asOpt must beSome(person)
+    }
+  }
+
+  "robustParsing" should {
+    "make invalid option values None" in {
+      val json = Json.obj(
+        "name" -> "Victor Hugo",
+        "age" -> 46,
+        "gender" -> true
+      )
+
+      Json.fromJson[Person](json).asOpt must beSome(Person("Victor Hugo", 46, None))
+      Json.fromJson[Person2](json).asOpt must beSome(Person2("Victor Hugo", 46))
+    }
+
+    "make invalid values with defaults fallback to the default" in {
+      val json = Json.obj(
+        "name" -> "Victor Hugo",
+        "age" -> "non age"
+      )
+
+      Json.fromJson[Person2](json).asOpt must beSome(Person2("Victor Hugo", 7))
+    }
+
+    "throw on invalid values which are not optional or default" in {
+      val json = Json.obj(
+        "name" -> "Victor Hugo",
+        "age" -> "non age"
+      )
+
+      val result = Json.fromJson[Person](json)
+      result must beAnInstanceOf[JsError]
+      result.asInstanceOf[JsError].errors.head._1.path.head.asInstanceOf[KeyPathNode].key mustEqual "age"
+
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.6-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
Connected to vital-software/scala-redox#54

This makes JSON parsing more robust.
1. If the field that failed to parse has a default value specified, it will be used
2. If the field that failed to parse is an optional value we default to None

This is done by first trying to parse by normal json reads and if that fails, we prune the failed properties from the json object and retry the parsing.

#### Concerns
This may apply defaults even for critical fields, and not throw an error. We need to make sure if they need defaults they are assigned a sensible defaults. As a more defensive alternative approach, we can use a tag like `@nonCritical` to only apply the robustness to non critical fields.
