### PR TITLE
Allow annotating final case classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow annotating final case classes
+
 ## [0.6.2] - 2019-11-05
 
 ### Added

--- a/src/main/scala/com/github/vitalsoftware/macros/JsonFormatAnnotation.scala
+++ b/src/main/scala/com/github/vitalsoftware/macros/JsonFormatAnnotation.scala
@@ -44,7 +44,14 @@ class jsonMacro(useDefaults: Boolean) {
         val q"case class $className(..$fields) extends ..$bases { ..$body }" = classDecl
         (className, fields)
       } catch {
-        case _: MatchError => c.abort(c.enclosingPosition, "Annotation is only supported on case class")
+        case _: MatchError =>
+          try {
+            val q"final case class $className(..$fields) extends ..$bases { ..$body }" = classDecl
+            (className, fields)
+          } catch {
+            case _: MatchError =>
+              c.abort(c.enclosingPosition, "Annotation is only supported on case class")
+          }
       }
 
     def jsonFormatter(className: TypeName, fields: List[ValDef]) =

--- a/src/test/scala/com/github/vitalsoftware/macros/JsonFormatAnnotationTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/macros/JsonFormatAnnotationTest.scala
@@ -6,6 +6,9 @@ import play.api.libs.json._
 @json case class Person(name: String, age: Int)
 @jsonDefaults case class Person2(name: String, age: Int = 7)
 
+sealed trait Foo extends Product with Serializable
+@jsonDefaults final case class Person3(name: String, age: Int = 7) extends Foo
+
 class JsonFormatAnnotationTest extends Specification {
   "@json annotation" should {
     "create correct formatter for case class with >= 2 fields" in {
@@ -28,6 +31,16 @@ class JsonFormatAnnotationTest extends Specification {
         "age" -> 7
       )
       Json.fromJson[Person2](Json.obj("name" -> "Victor Hugo")).asOpt must beSome(person)
+    }
+
+    "allow annotating final case classes" in {
+      val person = Person3("Victor Hugo")
+      val json = Json.toJson(person)
+      json === Json.obj(
+        "name" -> "Victor Hugo",
+        "age" -> 7
+      )
+      Json.fromJson[Person3](Json.obj("name" -> "Victor Hugo")).asOpt must beSome(person)
     }
   }
 }


### PR DESCRIPTION
It's a commonly specified best practice to mark defined case classes as final. See:
 - https://nrinaudo.github.io/scala-best-practices/tricky_behaviours/final_case_classes.html
 - https://github.com/alexandru/scala-best-practices/blob/master/sections/2-language-rules.md#221-case-classes-should-be-final

This library should allow annotating such final case classes

